### PR TITLE
Fixed PostgresError needing to be a type import for /products

### DIFF
--- a/src/routes/(protected)/products/+page.server.ts
+++ b/src/routes/(protected)/products/+page.server.ts
@@ -9,7 +9,8 @@ import {
 } from '@types';
 import { createCategory, createProduct } from '@server/mutations/product.mutation';
 import { slugifyString } from '@utils';
-import { PostgresError } from 'postgres';
+import type { PostgresError } from "postgres"
+
 import { queryCategoriesForCombobox, queryProducts } from '@server/queries';
 import { redirect } from '@sveltejs/kit';
 import { PRODUCT_STATUS } from '$lib/constants';


### PR DESCRIPTION
Thanks for all the work in putting together this example. It's been a great guide for working through Lucia and SvelteKit. 

I was getting this error:
```
[vite] Error when evaluating SSR module /src/routes/(protected)/products/+page.server.ts: failed to import "postgres"
|- SyntaxError: [vite] The requested module 'postgres' does not provide an export named 'PostgresError'
```
when trying to navigate to /products, or when hovering over the products icon on /dashboard (due to preload).

Changing from `import { PostgresError } from "postgres"` to `import type { PostgresError } from "postgres"` fixed it in my app, so I figured might as well fix it here too.

Thanks again.